### PR TITLE
Patch to preserve template variables original order

### DIFF
--- a/smartsnippets/models.py
+++ b/smartsnippets/models.py
@@ -31,11 +31,11 @@ class SmartSnippet(models.Model):
 
     def get_variables_list(self):
         t = self.get_template()
-        result = set()
+        result = list()
         for node in t.nodelist.get_nodes_by_type(VariableNode):
             v =  getattr(node.filter_expression.var, 'var', None)
-            if v and not v.endswith('_'):
-                result.add(v)
+            if v and not v.endswith('_') and v not in result:
+                result.append(v)
         return result
 
     def clean_template_code(self):


### PR DESCRIPTION
When adding a new snippet, variable names do not stay in order. The
following variables will appear randomized:
span1,
span2,
span3,

Becomes:
span3,
span1,
span2,

This is, most commonly, not what you want, since you cannot predict in
which order the end-user will see the variable fields.

This seems to be since the method SmartSnippet.get_variables_list uses a
set type var ("result") to collect unique variables from the template
before returning them.

I purpose a fix where a list is used ("result = list()") and on each
append of a variable it is checked against existing variables in list.
