### PR TITLE
Fixed cache invalidation issue

### DIFF
--- a/smartsnippets/models.py
+++ b/smartsnippets/models.py
@@ -108,7 +108,7 @@ class SmartSnippetPointer(CMSPlugin):
             # this is usefull for speeding up the cache invalidation
             # by not running the same query for each SmartSnippetVariable
             # that changed
-            cache.set(self.snippet.get_cache_key(), '1')
+            cache.set(self.snippet.get_cache_key(), '1', snippet_caching_time)
         return rendered_snippet
 
     def __unicode__(self):


### PR DESCRIPTION
Steps to reproduce: 
1. create a smart snippet 
2. add that smart snippet to a page 
3. preview the page 
4. wait for a couple of minutes 
      more than settings.CACHES['default']['TIMEOUT'](currently 1m) and less than SMARTSNIPPETS_CACHING_TIME (1h by default) 
5. change the smart snippet 
6. preview the page again 

Expected: 
change made at step 5 is visible 

Actual: 
the change is not there
