### PR TITLE
LUN-705 : Fix old promo snippets not showing merling objects

### DIFF
--- a/smartsnippets/templates/smartsnippets/snippet_change_form.html
+++ b/smartsnippets/templates/smartsnippets/snippet_change_form.html
@@ -30,91 +30,10 @@
         <script type="text/javascript">
         //<![CDATA[
         (function($) {
-            var LayoutListener = {
-
-                init : function(){
-                    if($('#id_snippet').find(":selected").text().match("One Promo")){
-                        this.bindChange()
-                        this.bindSubmit()
-                        this.chooseLayout()
-                        this.hideUnnecessaryFields()
-                        if($('#layout_help_button')){
-                            $('#layout_help_button').click(function(){
-                                LayoutListener.createHelpPoopup()
-                            })
-                        }
-                    }
-                },
-                
-                bindChange : function(){
-                    var self = this
-
-                    var layoutDropDown = $('#var_layout');
-                    
-                    layoutDropDown.change(function (e) {
-                                                
-                        self.chooseLayout()
-                    });
-                },
-
-                bindSubmit : function(){
-                    form = $('#smartsnippetpointer_form')
-
-                    form.submit(function(){
-                        LayoutListener.clearHiddenMerlinFields()
-                    })
-                },
-
-                clearHiddenMerlinFields : function(){
-
-                    var fields = $("tr[class^='section_topic']")
-                    fields.each(function(){
-                        if(!$(this).is(":visible")){
-                            $(this).find("input").each(function(){
-                                $(this).attr("value","")
-                            })
-                        }
-                    })  
-                },
-
-                hideUnnecessaryFields : function(){
-                    var labels = $('label').filter(function(index) { 
-                        return $(this).text() == "description" || $(this).text() == "published" 
-                    })
-
-                    labels.each(function(elem){
-                        $(this).parent().parent().remove()
-                    })
-                },
-
-                chooseLayout : function(){
-                    var fields = $("tr[class^='section_topic']")
-                    var selection = $('#var_layout').find(":selected").text()
-                    var range = parseInt(selection.charAt(0))
-                    
-                    if(isNaN(range)){
-                        range = 0
-                    }
-
-                    for(var i=0; i < fields.length; i++){
-                        
-                        if (i<range) {
-                            fields[i].setAttribute("style","")
-                        }else{
-                            fields[i].setAttribute("style","display:none")
-                        }
-                    }
-                },
-
-                createHelpPoopup : function(){
-                    newwindow = window.open("{{STATIC_URL}}images/explorer-white-promos.png",'Available layouts','height=468,width=826');
-                }
-            }
+           
 
             $(document).ready(function(){
                 $(".plugin-help-tooltip").tipTip({maxWidth: "250px", delay: 100});
-
-                LayoutListener.init()
                 
             });
         })(jQuery);

--- a/smartsnippets/templates/smartsnippets/widgets/dropdownfield/widget.html
+++ b/smartsnippets/templates/smartsnippets/widgets/dropdownfield/widget.html
@@ -7,10 +7,5 @@
                 <option {% if value == field.value %} selected="selected" {% endif %} value="{{ value }}" >{{ value }}</option>
             {% endfor %}
         </select>
-        {% if field.name == "layout" %}
-            <a id="{{ field.name }}_help_button" class="plugin-help-tooltip" style='float:none;font-size:17px' href='javascript:void(0)' target='_blank' title='Click link to see available layouts'>
-                <img src="{{STATIC_URL}}images/help.png">
-            </a>
-        {% endif %}
     </td>
 </tr>


### PR DESCRIPTION
- Old promo merlin objects were also hidden by One Promo snippet
- Hide uneccessary merlin fields for One Promo (ex : description, published)
