### PR TITLE
LUN-783 : Enable codemirror for editable smartsnippets

### DIFF
--- a/smartsnippets/static/admin/js/CMInstance.js
+++ b/smartsnippets/static/admin/js/CMInstance.js
@@ -1,0 +1,41 @@
+function CMInstance(elem, options, events){
+    if(!elem){
+        return null;
+    }
+
+    var codemirrorObj = null;
+
+    var defaults = {
+        continuousScanning: 500,
+        mode: 'htmlmixed',
+        height: "40.2em",
+        tabMode: "shift",
+        indentUnit: 4,
+        lineNumbers: true,
+        lineWrapping: true,
+        readOnly: true
+    };
+
+    //overwrite defaults if neccesary
+    if(options){
+        for(var j in options){
+            if(options.hasOwnProperty(j)){
+                defaults[j] = options[j];
+            }
+        }
+    }
+
+    //create CodeMirror instance
+    codemirrorObj = CodeMirror.fromTextArea(elem, defaults);
+
+    //attach events
+    if(events instanceof Array ){
+        for(var i=0; i<events.length; i++){
+            if(typeof events[i]['handler'] === 'function'){
+                codemirrorObj.on(events[i]['name'], events[i]['handler']);
+            }
+        }
+    }
+
+    return this;
+}

--- a/smartsnippets/static/admin/js/SmartSnippets.Variables.js
+++ b/smartsnippets/static/admin/js/SmartSnippets.Variables.js
@@ -413,17 +413,7 @@
 
 //            if ($.trim($(el).val()).length == 0) {//only when the area is empty
                 //use a setTimeout to capture pasted text
-                setTimeout(function () {
-
-                    var checkboxes = $('.delete input[type=checkbox]');
-                    $.each(checkboxes, function(i, box) {
-                        $(this).attr('checked', false);
-                    });
-
-                    var text = $(el).val();
-                    var varNames = LayoutParser.extractVarnames(text);
-                    LayoutParser.populate(varNames);
-                }, 100);
+                $.updateSnippetVars(el);
 //            }
         });
     });

--- a/smartsnippets/templates/smartsnippets/change_form.html
+++ b/smartsnippets/templates/smartsnippets/change_form.html
@@ -9,6 +9,7 @@
 <script type="text/javascript" src="{{ STATIC_URL}}admin/js/codemirror/javascript.js"></script>
 <script type="text/javascript" src="{{ STATIC_URL}}admin/js/codemirror/css.js"></script>
 <script type="text/javascript" src="{{ STATIC_URL}}admin/js/codemirror/xml.js"></script>
+<script type="text/javascript" src="{{ STATIC_URL}}admin/js/CMInstance.js"></script>
 
 <script type="text/javascript" src="{{ STATIC_URL}}admin/js/codemirror/htmlmixed.js"></script>
 {{ media }}

--- a/smartsnippets/templates/smartsnippets/fieldset.html
+++ b/smartsnippets/templates/smartsnippets/fieldset.html
@@ -17,16 +17,7 @@
                                 {% if field.field.name == "template_code" %}
                                         <textarea id='template_preview'>{{ field.contents }}</textarea>
                                         <script type="text/javascript">
-                                                CodeMirror.fromTextArea(django.jQuery('#template_preview')[0], {
-                                                        continuousScanning: 500,
-                                                        mode: 'htmlmixed',
-                                                        height: "40.2em",
-                                                        tabMode: "shift",
-                                                        indentUnit: 4,
-                                                        lineNumbers: true,
-                                                        lineWrapping: true,
-                                                        readOnly: true,
-                                                });
+                                            new CMInstance(django.jQuery('#template_preview')[0])
                                         </script>
                                 {% else %}
                                        <p>{{ field.contents }}</p>
@@ -35,24 +26,19 @@
                                 {{ field.field }}
                                 {% if field.field.name == "template_code" %}
                                     <script type="text/javascript">
-                                        var id_template_code = CodeMirror.fromTextArea(django.jQuery('#id_template_code')[0], {
-                                                continuousScanning: 500,
-                                                mode: 'htmlmixed',
-                                                height: "40.2em",
-                                                tabMode: "shift",
-                                                indentUnit: 4,
-                                                lineNumbers: true,
-                                                lineWrapping: true,
-                                                readOnly: false,
-                                        });
-
-                                        id_template_code.on("change", function(){
-                                            django.jQuery('#id_template_code')[0].value = id_template_code.getValue();
-                                            if(typeof django.jQuery.updateSnippetVars === 'function'){
-                                                django.jQuery.updateSnippetVars(django.jQuery('#id_template_code')[0])
-                                            }
-                                        })
-
+                                        new CMInstance(django.jQuery('#id_template_code')[0],
+                                            {
+                                                readOnly: false
+                                            },
+                                            [{
+                                                name: "change",
+                                                handler: function(target){
+                                                    django.jQuery('#id_template_code')[0].value = target.getValue();
+                                                    if(typeof django.jQuery.updateSnippetVars === 'function'){
+                                                        django.jQuery.updateSnippetVars(django.jQuery('#id_template_code')[0])
+                                                    }
+                                                }
+                                            }])
                                     </script>
                                 {% endif %}
                                 


### PR DESCRIPTION
- Enable code mirror for snippets that are not read only
- Enable line wrapping for code mirror so the horizontal scroll bar is not shown
  when code lines are too long
- Preserve snippet varibles automatic addition when pasting snippet code
- Snippet variables are added also as you type
